### PR TITLE
fix: exclude all kind of files

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,14 +12,16 @@ const domainMap = {
  * Fetch and log a request
  * @param {Request} request
  */
-async function handleRequest (request) {
+async function handleRequest(request) {
   const userAgent = request.headers.get('User-Agent') || ''
 
   // Check if incoming hostname is a key in the domainMap object
   let url = new URL(request.url)
   const target = domainMap[url.hostname]
+  // for any type of files just pass through it (including html but we dont care)
+  const isFile = request.url && request.url.split('/').pop().indexOf('.') > -1;
   // If it is, proxy request to that meta domain
-  if (target) {
+  if (target && !isFile) {
     if (crawlers.some(crawler => RegExp(crawler.pattern).test(userAgent))) {
       url.hostname = target
       return fetch(url, request)


### PR DESCRIPTION
we dont want to redirect the static files (e.g. png/jpg) as well, so this PR will add a regex check to filter out all type of files (including html/htm but we dont care in our use case)